### PR TITLE
Make SerialEvent more robust

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
     "name": "@pistonite/pure",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "exports": {
         "./fs": "./fs/index.ts",
         "./log": "./log/index.ts",


### PR DESCRIPTION
- Add last cancel check before returning
- Make sure cancel callback is fired at most once